### PR TITLE
Use "sandwich" heuristic.

### DIFF
--- a/globals.c
+++ b/globals.c
@@ -4,7 +4,7 @@
 */
 #include "globals.h"
 
-char magic_tag[4] = "v12";    // To indicate that we've written to EEPROM, so it's OK to use the values.
+char magic_tag[4] = "v20";    // To indicate that we've written to EEPROM, so it's OK to use the values.
             // MUST change this if the format/structure of persistent data has changed, which
             // will force unit into setup mode, with its own WiFi access point
 

--- a/globals.c
+++ b/globals.c
@@ -4,13 +4,15 @@
 */
 #include "globals.h"
 
-char magic_tag[4] = "v11";    // To indicate that we've written to EEPROM, so it's OK to use the values.
+char magic_tag[4] = "v12";    // To indicate that we've written to EEPROM, so it's OK to use the values.
             // MUST change this if the format/structure of persistent data has changed, which
             // will force unit into setup mode, with its own WiFi access point
 
 
 float current_temperature = IMPOSSIBLE_TEMPERATURE;
 float switch_temperature = IMPOSSIBLE_TEMPERATURE;
+float switch_offset_above = 0;
+float switch_offset_below = 0;
 SENSOR_DATA sensor_data = {0};
 
 // 0 means "off", which matches the start-up hardware state
@@ -35,7 +37,6 @@ struct PERSISTENT_DATA persistent_data = {
     20,     // max_time_between_reports, seconds
     20.0,   // desired temperature
     0.2,    // precision, used for enhanced stability when looking at temperature changes, esp. for change of direction
-    2.0, 2.0,   // max discrepancy values for scope of heuristic
     HEATING, // mode:  heating or cooling
 };
 
@@ -47,8 +48,6 @@ PERSISTENT_INFO persistents[] = {
     {PERS_INT8,   "rot",                        &persistent_data.rot},
     {PERS_FLOAT,  "desired_temperature",        &persistent_data.desired_temperature},
     {PERS_FLOAT,  "precision",                  &persistent_data.precision},
-    {PERS_FLOAT,  "max_discrepancy_down",       &persistent_data.max_discrepancy_down},
-    {PERS_FLOAT,  "max_discrepancy_up",         &persistent_data.max_discrepancy_up},
     {PERS_UINT8,  "mode",                       &persistent_data.mode},
     {0}
 };

--- a/globals.h
+++ b/globals.h
@@ -51,6 +51,8 @@ typedef struct {
 
 extern float current_temperature;
 extern float switch_temperature;
+extern float switch_offset_above;
+extern float switch_offset_below;
 extern SENSOR_DATA sensor_data;
 extern int8_t relay_state;
 extern uint8_t in_setup_mode;
@@ -72,8 +74,6 @@ struct PERSISTENT_DATA {    // this structure can be stored in EEPROM
     uint32_t max_time_between_reports;
     float   desired_temperature;
     float   precision;
-    float   max_discrepancy_down;
-    float   max_discrepancy_up;
     uint8_t mode;
 };
 extern struct PERSISTENT_DATA persistent_data;

--- a/home.html
+++ b/home.html
@@ -25,9 +25,15 @@ var on_colour = '#ff0000';
 var off_colour = '#00ff00';
 var switch_temp_colour = '#F020D0';
 
-var canvas;
+var the_canvas;
 var ctx;
 var value_lists = [];
+
+// provide a shorter name for document.getElementById
+function getdocelem(elid)
+{
+    return document.getElementById(elid);
+}
 
 function int32ToStr(num)
 {
@@ -55,35 +61,34 @@ function normalizeNumber(n)
 
 function getTextWidth(item_id)
 {
-   return document.getElementById(item_id).getBoundingClientRect().width;
+   return getdocelem(item_id).getBoundingClientRect().width;
 }
 
-function setSizes(des_temperature, temperature)
+function setSizes(des_temperature, temp)
 {
-    var temp_diff = temperature - des_temperature;
+    var temp_diff = temp - des_temperature;
     var off_from_target = Math.abs(temp_diff);
     var bar_width = 2 * Math.max(1, Math.ceil(0.1 + off_from_target * 2) / 2);
     var min_temp_on_bar = des_temperature - bar_width / 2;
-    var pix_per_deg = document.getElementById('temperaturebar').width / bar_width;
-      document.getElementById('temperaturebandindent').width = ((bar_width - 1) / 2) * pix_per_deg;
-      document.getElementById('temperatureband').width = pix_per_deg;
-      document.getElementById('temperatureindicatorindent').width = (temperature - min_temp_on_bar) * pix_per_deg -
-                    document.getElementById('temperatureindicator').width / 2;
+    var pix_per_deg = getdocelem('temperaturebar').width / bar_width;
+      getdocelem('temperaturebandindent').width = ((bar_width - 1) / 2) * pix_per_deg;
+      getdocelem('temperatureband').width = pix_per_deg;
+      getdocelem('temperatureindicatorindent').width = (temp - min_temp_on_bar) * pix_per_deg -
+                    getdocelem('temperatureindicator').width / 2;
 
-      document.getElementById('ctemp').innerHTML =  normalizeNumber(temperature);
-      document.getElementById('indent').width = document.getElementById('temperatureindicatorindent').width -
+      getdocelem('ctemp').innerHTML =  normalizeNumber(temp);
+      getdocelem('indent').width = getdocelem('temperatureindicatorindent').width -
              getTextWidth('ctemp') / 2;
-      document.getElementById('mintemp').innerHTML = normalizeNumber(min_temp_on_bar);
-      document.getElementById('destemp').innerHTML = normalizeNumber(des_temperature);
-      document.getElementById('indentpredes').width = (document.getElementById('temperaturebar').width 
+      getdocelem('mintemp').innerHTML = normalizeNumber(min_temp_on_bar);
+      getdocelem('destemp').innerHTML = normalizeNumber(des_temperature);
+      getdocelem('indentpredes').width = (getdocelem('temperaturebar').width 
                                             - getTextWidth('destemp')) / 2
                                             - getTextWidth('mintemp');
-      document.getElementById('maxtemp').innerHTML = normalizeNumber(des_temperature + bar_width / 2);
-      document.getElementById('indentmaxtemp').width = document.getElementById('temperaturebar').width
-                - getTextWidth('mintemp') - document.getElementById('indentpredes').width
+      getdocelem('maxtemp').innerHTML = normalizeNumber(des_temperature + bar_width / 2);
+      getdocelem('indentmaxtemp').width = getdocelem('temperaturebar').width
+                - getTextWidth('mintemp') - getdocelem('indentpredes').width
                 - getTextWidth('destemp')
                 - getTextWidth('maxtemp');
-    temperature += 0.1;
 }
 
 function parseXml(xmlStr)
@@ -94,22 +99,22 @@ function parseXml(xmlStr)
 // valarray is an array of array of colours, line-widths and new values, one triple for each trace
 function updateGraph(valarray)
 {
-    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.clearRect(0, 0, the_canvas.width, the_canvas.height);
     ctx.save();
     ctx.beginPath();
     ctx.lineWidth = 1;
     ctx.strokeStyle = '#333333';    // dark centre line
-    ctx.moveTo(0, canvas.height / 2);
-    ctx.lineTo(canvas.width, canvas.height / 2);
+    ctx.moveTo(0, the_canvas.height / 2);
+    ctx.lineTo(the_canvas.width, the_canvas.height / 2);
     ctx.stroke();
     ctx.beginPath();
     ctx.lineWidth = 1;
     ctx.strokeStyle = '#888888';    // light upper and lower lines
     ctx.setLineDash([5, 3]);
-    ctx.moveTo(0, canvas.height / 2 + canvas.height / 10);
-    ctx.lineTo(canvas.width, canvas.height / 2 + canvas.height / 10);
-    ctx.moveTo(0, canvas.height / 2 - canvas.height / 10);
-    ctx.lineTo(canvas.width, canvas.height / 2 - canvas.height / 10);
+    ctx.moveTo(0, the_canvas.height / 2 + the_canvas.height / 10);
+    ctx.lineTo(the_canvas.width, the_canvas.height / 2 + the_canvas.height / 10);
+    ctx.moveTo(0, the_canvas.height / 2 - the_canvas.height / 10);
+    ctx.lineTo(the_canvas.width, the_canvas.height / 2 - the_canvas.height / 10);
     ctx.stroke();
     ctx.restore();
     ctx.save();
@@ -142,105 +147,105 @@ function drawPlot(value_list)
     }
 }
 
+function signedNumber(num)
+{
+    return ((num > 0) ? '+' : '') + num;
+}
+
 // colours distinct from each other and from red/green used for the controlling trace, and from purple for the switch temperature
 var dot_colours = ['#808080', '#0b84a5', '#6f4e7c', '#ca472f']; // distinct from each other and from red/green used for the controlling trace
 function gotStatusResponse()
 {
    if (xhttp.status == 200)
    {
-       try
-        {
-          var xmlDoc;
-          if (window.DOMParser)
+      var xmlDoc;
+      if (window.DOMParser)
+      {
+          parser = new DOMParser();
+          xmlDoc = parser.parseFromString(xhttp.responseText, 'text/xml');
+      }
+      else // Internet Explorer
+      {
+          xmlDoc = new ActiveXObject('Microsoft.XMLDOM');
+          xmlDoc.async = false;
+          xmlDoc.loadXML(xhttp.responseText);
+      }
+      var cur_temp = 1 * xmlDoc.getElementsByTagName('tmp')[0].childNodes[0].nodeValue;
+      var relay_state = 1 * xmlDoc.getElementsByTagName('state')[0].childNodes[0].nodeValue;
+      var des_temperature = 1 * xmlDoc.getElementsByTagName('des')[0].childNodes[0].nodeValue;
+      var switchoffsetabove_val = 1 * xmlDoc.getElementsByTagName('switchoffsetabove')[0].childNodes[0].nodeValue;
+      var switchoffsetbelow_val = 1 * xmlDoc.getElementsByTagName('switchoffsetbelow')[0].childNodes[0].nodeValue;
+      var mode_val = xmlDoc.getElementsByTagName('mode')[0].childNodes[0].nodeValue;
+      var switchtempabove = des_temperature + switchoffsetabove_val;
+      var switchtempbelow = des_temperature + switchoffsetbelow_val;
+
+      getdocelem('onoffimg').src = (relay_state == 1)
+            ? (mode_val == 'heating' ? red_image : blue_image)
+            : green_image;
+      getdocelem('onofftext').textContent = 'Power ' + ((relay_state == 1) ? ('on (' + mode_val + ')') : 'off');
+      getdocelem('displaytargettemp').textContent = des_temperature;
+      getdocelem('displayprecision').textContent = xmlDoc.getElementsByTagName('prec')[0].childNodes[0].nodeValue;
+      getdocelem('displayreptime').textContent = xmlDoc.getElementsByTagName('maxrep')[0].childNodes[0].nodeValue;
+      getdocelem('displaymode').textContent = mode_val;
+      getdocelem('displayswitchabovetemp').textContent = switchtempabove;
+      getdocelem('displayswitchbelowtemp').textContent = switchtempbelow;
+      getdocelem('displayswitchoffsetabove').textContent = signedNumber(switchoffsetabove_val);
+      getdocelem('displayswitchoffsetbelow').textContent = signedNumber(switchoffsetbelow_val);
+
+      // Temperature bar
+      setSizes(des_temperature, cur_temp);
+
+      // Graph
+      var new_values = [];
+      var main_dot_colour = (relay_state == 1) ? on_colour : off_colour;
+      var temps = xmlDoc.getElementsByTagName('tmp');
+
+      getdocelem('controlsensorid').textContent = temps[0].id;
+      getdocelem('controlsensorvalue').textContent = temps[0].childNodes[0].nodeValue;
+
+      var i = 0;
+      var doc_legend_elem = getdocelem('legend');
+      while (doc_legend_elem.lastChild) {
+        doc_legend_elem.removeChild(doc_legend_elem.lastChild);
+      }
+
+      getdocelem('othersensors').style.display = (temps.length < 2) ? 'none' : 'block';
+
+      // start with lines for switch temperatures
+      new_values.push( [switch_temp_colour, 1, getGraphPos(switchtempabove, des_temperature)] );
+      new_values.push( [switch_temp_colour, 1, getGraphPos(switchtempbelow, des_temperature)] );
+
+      for (let tmp_elem of temps)
+      {
+          var tmp = tmp_elem.childNodes[0].nodeValue;
+          var dot_colour, font_colour, line_width;
+          if (i == 0)
           {
-              parser = new DOMParser();
-              xmlDoc = parser.parseFromString(xhttp.responseText, 'text/xml');
+              // first sensor is currently hard-coded as the controlling one
+              // no list item, as this is already displayed in the html
+              dot_colour = main_dot_colour;
+              line_width = 2;
           }
-          else // Internet Explorer
+          else
           {
-              xmlDoc = new ActiveXObject('Microsoft.XMLDOM');
-              xmlDoc.async = false;
-              xmlDoc.loadXML(xhttp.responseText);
+              list_item = document.createElement('li');
+              font_colour = dot_colour = dot_colours[i % dot_colours.length];
+              list_item.style.color = dot_colour;
+              line_width = 1;
+              list_item.innerHTML = '<pre><font color=\"' + font_colour + '\">' + tmp_elem.id + '</font> ' + tmp + '</pre>';
+              doc_legend_elem.appendChild(list_item);
           }
-          var temperature = 1 * xmlDoc.getElementsByTagName('tmp')[0].childNodes[0].nodeValue;
-          var relay_state = 1 * xmlDoc.getElementsByTagName('state')[0].childNodes[0].nodeValue;
-          var des_temperature = 1 * xmlDoc.getElementsByTagName('des')[0].childNodes[0].nodeValue;
-          var maxdiscrepdown = 1 * xmlDoc.getElementsByTagName('maxdiscrepdown')[0].childNodes[0].nodeValue;
-          var maxdiscrepup   = 1 * xmlDoc.getElementsByTagName('maxdiscrepup')[0].childNodes[0].nodeValue;
-          var switch_temp    = 1 * xmlDoc.getElementsByTagName('switch')[0].childNodes[0].nodeValue;
-          var mode = xmlDoc.getElementsByTagName('mode')[0].childNodes[0].nodeValue;
-
-          document.getElementById('onoffimg').src = (relay_state == 1)
-                ? (mode == 'heating' ? red_image : blue_image)
-                : green_image;
-          document.getElementById('onofftext').textContent = 'Power ' + ((relay_state == 1) ? ('on (' + mode + ')') : 'off');
-          document.getElementById('displaytargettemp').textContent = des_temperature;
-          document.getElementById('displayprecision').textContent = xmlDoc.getElementsByTagName('prec')[0].childNodes[0].nodeValue;
-          document.getElementById('displayreptime').textContent = xmlDoc.getElementsByTagName('maxrep')[0].childNodes[0].nodeValue;
-          document.getElementById('displaymode').textContent = mode;
-          document.getElementById('maxdiscrepdown').textContent = maxdiscrepdown;
-          document.getElementById('maxdiscrepup').textContent = maxdiscrepup;
-
-          // Temperature bar
-          setSizes(des_temperature, temperature);
-
-          // Graph
-          var new_values = [];
-          var main_dot_colour = (relay_state == 1) ? on_colour : off_colour;
-          var temps = xmlDoc.getElementsByTagName('tmp');
-
-          document.getElementById('controlsensorid').textContent = temps[0].id;
-          document.getElementById('controlsensorvalue').textContent = temps[0].childNodes[0].nodeValue;
-          document.getElementById('switchtemperaturevalue').textContent = switch_temp;
-
-          var i = 0;
-          var doc_legend_elem = document.getElementById('legend');
-          while (doc_legend_elem.lastChild) {
-            doc_legend_elem.removeChild(doc_legend_elem.lastChild);
-          }
-
-          document.getElementById('othersensors').style.display = (temps.length < 2) ? 'none' : 'block';
-
-          // start with line for switch_temperature
-          new_values.push( [switch_temp_colour, 1, getGraphPos(switch_temp, des_temperature)] );
-
-          for (let tmp_elem of temps)
-          {
-              var tmp = tmp_elem.childNodes[0].nodeValue;
-              var dot_colour, font_colour, line_width;
-              if (i == 0)
-              {
-                  // first sensor is currently hard-coded as the controlling one
-                  // no list item, as this is already displayed in the html
-                  dot_colour = main_dot_colour;
-                  line_width = 2;
-              }
-              else
-              {
-                  list_item = document.createElement('li');
-                  font_colour = dot_colour = dot_colours[i % dot_colours.length];
-                  list_item.style.color = dot_colour;
-                  line_width = 1;
-                  list_item.innerHTML = '<pre><font color=\"' + font_colour + '\">' + tmp_elem.id + '</font> ' + tmp + '</pre>';
-                  doc_legend_elem.appendChild(list_item);
-              }
-              new_values.push( [dot_colour, line_width, getGraphPos(1 * tmp, des_temperature)] );
-              i +=1;
-          }
-          updateGraph(new_values);
-          // End of graph
-       }
-   catch (err)
-       {
-        // catch all errors, for info and to allow the reschedule to happen
-        console.log('Failed: ' + err.message);
-       }
+          new_values.push( [dot_colour, line_width, getGraphPos(1 * tmp, des_temperature)] );
+          i +=1;
+      }
+      updateGraph(new_values);
+      // End of graph
    }
 }
 function getGraphPos(temp, des)
 {
     var temp_diff = temp - des;
-    var point_height = canvas.height / 2 + canvas.height * temp_diff / 5;    // assume 5deg spread on graph
+    var point_height = the_canvas.height / 2 + the_canvas.height * temp_diff / 5;    // assume 5deg spread on graph
     return point_height;
 }
 
@@ -255,15 +260,15 @@ function fetchStatus()
 function startGettingStatus()
 {
     // set temperature bar colour images
-    document.getElementById('temperaturebar').src = black_image;
-    document.getElementById('temperatureband').src = green_image;
-    document.getElementById('temperatureindicator').src = red_image;
-    canvas = document.getElementById('graphCanvas');
+    getdocelem('temperaturebar').src = black_image;
+    getdocelem('temperatureband').src = green_image;
+    getdocelem('temperatureindicator').src = red_image;
+    the_canvas = getdocelem('graphCanvas');
     // we might want these values to differ from full width/height, if there's other stuff on the canvas
-    graph_height = canvas.height;
-    graph_width = canvas.width;
-    ctx = canvas.getContext('2d');
-    canvas.style.border = 'black 1px solid';
+    graph_height = the_canvas.height;
+    graph_width = the_canvas.width;
+    ctx = the_canvas.getContext('2d');
+    the_canvas.style.border = 'black 1px solid';
     setInterval(fetchStatus, 2000);
     fetchStatus(); // do one immediately
 }
@@ -284,7 +289,7 @@ function gotChangeSettingsResponse()
 
 function submitSettingsForm()
 {
-   var form = document.getElementById('settings-form');
+   var form = getdocelem('settingsform');
    var form_elems = form.getElementsByTagName('input');
    var params = '';
    for (var idx = 0; idx < form_elems.length; ++idx)
@@ -354,30 +359,29 @@ E.g. at 16 with target 17.5:
 <br><font color='#ff0000'>&#9679;</font>/<font color='#00ff00'>&#9679;</font>Controlling sensor 
     <span id=controlsensorid>??</span> <span id=controlsensorvalue>??</span>
 <!-- switch temperature -->
-<br><font color='#F020D0'>&#9679;</font>Switch temperature
-    <span id=switchtemperaturevalue>??</span> (range -<span id=maxdiscrepdown>??</span>,<span id=maxdiscrepup>??</span>)
+<br><font color='#F020D0'>&#9679;</font>Switch temperatures
+    <span id=displayswitchbelowtemp>??</span>-<span id=displayswitchabovetemp>??</span>
 <p id=othersensors>Other sensors:
 <ul id='legend' style='line-height:20%'>
 </ul>
 </p>
 
 <p>
-Target temperature degC: <span id=displaytargettemp>??</span>
+Target temperature degC: <span id=displaytargettemp>??</span> (<span id=displayswitchoffsetbelow>??</span> to <span id=displayswitchoffsetabove>??</span>)
 <br>Mode: <span id=displaymode>??</span>
 <br>Precision degC: <span id=displayprecision>??</span>
 <br>Max. time (seconds) between reports: <span id=displayreptime>??</span>
 </p>
 
 <h3>Change settings</h3>
-<form id='settings-form'>
-Target temperature degC: <input type=text id=des_input name=des_temp value='' />
-        <input type=radio name=mode value=0 id=heatingmode >heating or 
-        <input type=radio name=mode value=1 id=coolingmode >cooling
-<br>Precision degC: <input type=text id=precision name=precision value='' />
+<form id=settingsform>
+Target temperature degC: <input type=text size=4 name=des_temp value='' />
+        <input type=radio name=mode value=0 >heating or 
+        <input type=radio name=mode value=1 >cooling
+<br>Precision degC: <input type=text size=4 name=precision value='' />
 <br><span style='font-size:smaller'>This gives the minimum change in temperature that will be noticed.
 Set to a high value to give more inertia to both reporting and relay switching.</span>
-<br>Temperature range degC for heuristic: below: <input type=text name=maxdiscrepdown value='' /> above: <input type=text name=maxdiscrepup value='' />
-<br>Max. time (seconds) between reports: <input type=text id=maxreporttime name=maxreporttime value='' />
+<br>Max. time (seconds) between reports: <input type=text size=4 name=maxreporttime value='' />
 <br><span style='font-size:smaller'>This forces a report to be sent after the specified time
 even if there was no reportable event.
 Reportable events are switching the relay on or off,

--- a/mkhtmlfile
+++ b/mkhtmlfile
@@ -1,7 +1,11 @@
 #!/usr/bin/python3
 # Generate c-file and matching .h file from a text file by appending \n and enclosing in double quotes.
-# It would be good to strip comments, both html and JavaScript, to reduce image size.
-# And maybe collapse white-space.
+# Strip comments, both html and JavaScript, and unnecessary white space, to reduce image size.
+# Replace all element IDs and variable and function names that are 4 or more characters long with shorter words.
+#   Take care with the above. Make sure that your don't use the same names for different purposes. This is
+#   why, for example, some variables are called <something>_val rather than just <something>, so as not
+#   to conflict with element IDs or input field names.
+# Collapse white-space in <head>.
 
 import hashlib
 import os
@@ -18,6 +22,9 @@ multi_newline_re = re.compile(r'\n\n+')
 hex_value_re = re.compile(r'\\x')
 escaped_quote_re = re.compile(r"\\'")
 backslash_n_re = re.compile(r'\\n')
+element_id_re = re.compile(r"\bid='?([\w]{4,})'?")
+var_re = re.compile(r'\bvar  *([\w]{4,})')
+func_re = re.compile(r'\bfunction  *([\w]{4,})')
 
 text = open(infilename).read()
 
@@ -30,6 +37,29 @@ text = escaped_quote_re.sub(r"\\\\'", text)
 text = backslash_n_re.sub(r"\\\\n", text)
 
 etag = hashlib.md5(text.encode('UTF8')).hexdigest()
+
+#print(text, file=open('/tmp/before', 'w'))
+for item_re, prefix in (
+            (element_id_re, 'e',),
+            (var_re, 'v',),
+            (func_re, 'f',),
+        ):
+    orig_names = set(item_re.findall(text))
+    for n, orig_name in enumerate(sorted(orig_names)):  # sorted is for debugging purposes, to compare successive runs
+        text = re.sub(rf'\b{orig_name}\b', f'{prefix}{n}', text)
+
+text = re.sub(' = ', '=', text)
+text = re.sub('^ ', '', text, flags=re.MULTILINE)
+
+# Strip newlines and unnecessary spaces around operators, separators and delimiters.
+# Dont strip *all* newlines as it breaks some of the HTML layout
+end_head_pos = text.find('</head>')
+# strip unnecessary spaces around operators, separators and delimiters
+head_sect = re.sub(' ?([-+/=<>,;:&?*]) ?', r'\1', text[:end_head_pos].replace('\n', ''))
+text = head_sect + text[end_head_pos:]
+
+text = text.strip()
+#print(text, file=open('/tmp/after', 'w'))
 
 with open(base + '_html.c', 'w') as f:
     f.write('char %s_etag[] = "%s";\nchar %s_html[] =\n' % (base, etag, base))

--- a/network.cpp
+++ b/network.cpp
@@ -334,10 +334,10 @@ void getResponse()
     client.stop();
 }
 
-void sendReport(float current_temperature, float switch_temperature, int relay_state,
+void sendReport(float current_temperature, int8_t relay_state,
+        float switch_offset_below, float switch_offset_above,
         const char *comment, SENSOR_DATA *sensor_data)
 {
-    DOPRINTLN("sendReport");
     if (!connectTCP())
     {
         char *sanitized_txt = (char*)malloc(strlen(comment) + 1);
@@ -356,8 +356,10 @@ void sendReport(float current_temperature, float switch_temperature, int relay_s
         client.print(persistent_data.desired_temperature);
         client.print("&tmp=");
         client.print(current_temperature);
-        client.print("&sw=");
-        client.print(switch_temperature);
+        client.print("&below=");
+        client.print(switch_offset_below);
+        client.print("&above=");
+        client.print(switch_offset_above);
         client.print("&relay=");
         client.print(relay_state ? "on" : "off");
         client.print("&txt=");
@@ -378,7 +380,7 @@ void sendReport(float current_temperature, float switch_temperature, int relay_s
         client.print("Host:");          // Send Host header even though it's optional in 1.0, because Nginx insists on it. Sigh...
         client.print(p_report_hostname);
         client.print("\r\n\r\n");
-        getResponse();
+        getResponse();  // includes client.stop()
     }
     setLEDflashing(0, 0);
 }

--- a/network.h
+++ b/network.h
@@ -11,7 +11,8 @@ void startAccessPoint();
 uint8_t connectWiFi();
 int connectTCP();
 void getResponse(WiFiClient client);
-void sendReport(float current_temperature, float switch_temperature, int relay_state,
+void sendReport(float current_temperature, int8_t relay_state,
+        float switch_offset_below, float switch_offset_above,
         const char *comment, SENSOR_DATA *sensor_data);
 uint8_t getSettings();
 

--- a/sensors.h
+++ b/sensors.h
@@ -23,6 +23,5 @@ typedef enum {
 
 void readSensors(SENSOR_DATA *result);
 int readDsTemp(int start, TEMPERATURE_DATA *res);
-extern void generateSensorPage(String *page, SENSOR_DATA sensor_data);
 
 #endif  // _SENSORS_H

--- a/testing/heatersim.py
+++ b/testing/heatersim.py
@@ -20,10 +20,10 @@ state_filename = 'state'
 min_temp = 5
 max_temp = 65
 sleep_time = 0.1
-heat_rate         = 3       # fixed amount of degrees of heat per iteration
-cool_delta_ratio  = 0.1     # proportion per second by which internal temp approaches ambient temp
+heat_rate         = 0.1       # fixed amount of degrees per second
+cool_delta_ratio  = 0.02     # proportion per second by which internal temp approaches ambient temp
 transfer_delta_ratio  = 0.005     # proportion per second by which temp approaches internal temp
-switch_delay = 3
+switch_delay = 4
 
 mode = 'heating'    # or cooling
 

--- a/testing/initialize
+++ b/testing/initialize
@@ -9,5 +9,5 @@ then
     echo 11 >temperature
 else
     echo 20 >target_temperature 
-    echo 19 >temperature
+    echo 19.5 >temperature
 fi

--- a/testing/mkMain
+++ b/testing/mkMain
@@ -1,23 +1,31 @@
 #!/usr/bin/bash
 
-# extract assessRelayStateAverage, wrap it in a main() that reads something on stdin and
-# echoes a new relay state
+# extract assessRelayState and its requirements, wrap it in a main() that simulates the rest of the program.
 
-cp simwrapper.c sim.cpp
+sed '/^int main/,$ d' simwrapper.c >sim.cpp
 sed -n -e '/^static[^(]*$/ p' \
+       -e '/^extern /p' \
        -e '/^#define /p' \
+       -e '/^const char /p' \
+       -e '/^enum PERIOD_STATE/p' \
+       -e '/^typedef/p' \
        -e '/^static int8_t assessRelayState/,/^}$/ p' \
        -e '/^float normalizeTemperature/,/^}$/ p' \
-       -e '/^static void setIfImpossible/,/^}$/ p' \
-       -e '/^static void assessPerformance/,/^}$/ p' \
        -e '/^static void handlePeaksAndTroughs/,/^}$/ p' \
+       -e '/^static void assessPerformance/,/^}$/ p' \
+       -e '/^static void setIfImpossible/,/^}$/ p' \
+       -e '/^static void recordSwitchedOn/,/^}$/ p' \
+       -e '/^static void recordSwitchedOff/,/^}$/ p' \
        ../thermostat.ino | grep -v 'static.*millis_now' >>sim.cpp
+sed -n '/^int main/,$ p' simwrapper.c >>sim.cpp
 
 cat <<EnD >globals.h
 #include <iostream>
 enum RELAY_STATE {POWER_OFF, POWER_ON};
 static int8_t assessRelayState(int8_t pre_relay_state);
 float normalizeTemperature(float temperature);
+#define DOPRINT(x) std::cerr << (x)
+#define DOPRINTLN(x) {DOPRINT(x); std::cerr << "\n"; }
 EnD
 grep -v -e 'Arduino.h' -e 'DOPRINT' ../globals.h >>globals.h
 cp ../globals.c globals.cpp

--- a/testing/settings.cgi
+++ b/testing/settings.cgi
@@ -23,13 +23,13 @@
 #
 # (The above description works in Apache2. A different approach may be needed on other web servers.)
 
-# example QUERY_STRING for setting values: des_temp=11&mode=0&precision=0.20&maxreporttime=12&maxdiscrepdown=2&maxdiscrepup=2
+# example QUERY_STRING for setting values: des_temp=11&mode=0&precision=0.20&maxreporttime=12&switchoffsetabove=0.5&switchoffsetbelow=-0.8
 #   des_temp=11
 #   mode=0
 #   precision=0.20
 #   maxreporttime=12
-#   maxdiscrepdown=2
-#   maxdiscrepup=2
+#   switchoffsetabove=0.5
+#   switchoffsetbelow=-0.8
 
 if test ! -f status
 then
@@ -43,8 +43,8 @@ then
  <prec>0.20</prec>
  <mode>heating</mode>
  <switch>12</switch>
- <maxdiscrepdown>2</maxdiscrepdown>
- <maxdiscrepup>2</maxdiscrepup>
+ <switchoffsetabove>0.5</switchoffsetabove>
+ <switchoffsetbelow>-0.8</switchoffsetbelow>
  <maxrep>120</maxrep>
 </status>
 EnD
@@ -62,8 +62,8 @@ awk -v $(echo $QUERY_STRING | sed 's/&/ -v /g') '
     /<des>/ {rep("des", des_temp)}
     /<mode>/ && mode != "" {rep("mode", mode == "0" ? "heating" : "cooling" )}
     /<prec>/ {rep("prec", precision)}
-    /<maxdiscrepdown>/ {rep("maxdiscrepdown", maxdiscrepdown)}
-    /<maxdiscrepup>/ {rep("maxdiscrepup", maxdiscrepup)}
+    /<switchoffsetabove>/ {rep("switchoffsetabove", switchoffsetabove)}
+    /<switchoffsetbelow>/ {rep("switchoffsetbelow", switchoffsetbelow)}
     /<maxrep>/ {rep("maxrep", maxreporttime)}
     {print}
 ' status >status.new && mv status.new status

--- a/testing/updateStatusForSim
+++ b/testing/updateStatusForSim
@@ -1,10 +1,11 @@
 while sleep 1
 do
-    sw=$(<switch)
     tmp=$(<temperature)
     des=$(<target_temperature)
     statestr=$(<state)
     mode=$(<mode)
+    switch_offset_above=$(<switch_offset_above)
+    switch_offset_below=$(<switch_offset_below)
     if test $statestr = ON
     then
         state=1
@@ -12,10 +13,11 @@ do
         state=0
     fi
     sed -i \
-        -e '/<switch>/ s/>[0-9.]*</>'$sw'</' \
-        -e '/<tmp / s/>[0-9.]*</>'$tmp'</' \
-        -e '/<state>/ s/>[0-9.]*</>'$state'</' \
+        -e '/<tmp / s/>[^<]*</>'$tmp'</' \
+        -e '/<state>/ s/>[^<]*</>'$state'</' \
+        -e '/<switchoffsetabove>/ s/>[^<]*</>'$switch_offset_above'</' \
+        -e '/<switchoffsetbelow>/ s/>[^<]*</>'$switch_offset_below'</' \
         -e '/<mode>/ s/>[^<]*</>'$mode'</' \
-        -e '/<des>/ s/>[0-9.]*</>'$des'</' \
+        -e '/<des>/ s/>[^<]*</>'$des'</' \
     /var/www/html/status
 done

--- a/webserver.cpp
+++ b/webserver.cpp
@@ -83,11 +83,10 @@ static void sendStatus(AsyncWebServerRequest *request)
     response += String(" <state>") + String(relay_state) + String("</state>\n") +
             String(" <des>")   + String(persistent_data.desired_temperature) + String("</des>\n") +
             String(" <prec>")   + String(persistent_data.precision) + String("</prec>\n") +
-            String(" <switch>")   + String(switch_temperature) + String("</switch>\n") +
+            String(" <switchoffsetabove>")   + String(switch_offset_above) + String("</switchoffsetabove>\n") +
+            String(" <switchoffsetbelow>")   + String(switch_offset_below) + String("</switchoffsetbelow>\n") +
             String(" <mode>")   + String(persistent_data.mode == HEATING ? "heating" : "cooling") + String("</mode>\n") +
             String(" <maxrep>")   + String(persistent_data.max_time_between_reports) + String("</maxrep>\n") +
-            String(" <maxdiscrepdown>")   + String(persistent_data.max_discrepancy_down) + String("</maxdiscrepdown>\n") +
-            String(" <maxdiscrepup>")   + String(persistent_data.max_discrepancy_up) + String("</maxdiscrepup>\n") +
         String("</status>\n");
     DEBUGDOPRINTLN(response);
     request->send(200, "text/xml", response);
@@ -168,14 +167,6 @@ static void settings(AsyncWebServerRequest *request)
         else if (p->name() == "precision")
         {
             made_a_change |= checkAndSetPersistentFloatValue("precision", p->value().c_str(), &persistent_data.precision);
-        }
-        else if (p->name() == "maxdiscrepdown")
-        {
-            made_a_change |= checkAndSetPersistentFloatValue("maxdiscrepdown", p->value().c_str(), &persistent_data.max_discrepancy_down);
-        }
-        else if (p->name() == "maxdiscrepup")
-        {
-            made_a_change |= checkAndSetPersistentFloatValue("maxdiscrepup", p->value().c_str(), &persistent_data.max_discrepancy_up);
         }
         else if (p->name() == "maxreporttime")
         {


### PR DESCRIPTION
- Improved heuristic. Use an upper and lower value to control switching, instead of a simple switch temperature.
    - Removed max offsets from persistent memory (so EEPROM is incompatible with previous versions).
    - Significantly reduced size of home web page by automatically reducing symbolic names.
    - Removed obsolete generateSensorPage() declaration.
    - Adjust sleep time to set a minimum between loops, taking into account time spent in loop.
NB. New magic_tag, as format/content of EEPROM data has changed.
